### PR TITLE
Testing

### DIFF
--- a/devicetypes/dcoffing/kof-zigbee-fan-controller-fan-speed-child-device.src/kof-zigbee-fan-controller-fan-speed-child-device.groovy
+++ b/devicetypes/dcoffing/kof-zigbee-fan-controller-fan-speed-child-device.src/kof-zigbee-fan-controller-fan-speed-child-device.groovy
@@ -17,9 +17,8 @@ KNOWN ISSUES
  - fan and light child device views are only available in iOS mobile app
  - Fan child device view can't change name when using gear icon like you can in Light child device
  */ 
- def version() {return "ver 0.2.1.20170510"}
+ def version() {return "ver 0.2.1.20170515"}
  /*
- 05/10 trying without the flat look, with the large icons it doesn't balance well, return back to flat look
     a- trying 2x2 tile for child devices
  05/04 clean up of unneeded commented code lines, clean up display in iOS child version w/ smaller text and center version
  05/03 renaming PUSH to ENABLE on the label
@@ -50,7 +49,7 @@ metadata {
    }
    
    tiles(scale: 2) {
-// standardTile("fanSpeed", "fanSpeed", decoration: "flat", width: 2, height: 2) {  
+
         standardTile("fanSpeed", "fanSpeed", decoration: "flat", width: 2, height: 2) {  
      		state "off", label:"off", action: "on", icon: getIcon()+"fan00h_grey.png", backgroundColor: "#ffffff", nextState: "turningOn"
             state "on01", label: "LOW", action: "off", icon: getIcon()+"fan1j_on.png", backgroundColor: "#79b821", nextState: "turningOff"
@@ -62,7 +61,7 @@ metadata {
            	state "off02", label: "MED", action: "on", icon: getIcon()+"fan2j_off.png", backgroundColor: "#ffffff", nextState: "turningOn"
 			state "off03", label: "MED-HI", action: "on", icon: getIcon()+"fan3j_off.png", backgroundColor: "#ffffff", nextState: "turningOn"
 			state "off04", label: "HIGH", action: "on", icon: getIcon()+"fan4j_off.png", backgroundColor: "#ffffff", nextState: "turningOn"
-			state "off06", label: "ENABLE", action: "on", icon: getIcon()+"breeze4h_off.png", backgroundColor: "#ffffff", nextState: "turningBreezeOn"
+			state "off06", label: "BREEZE", action: "on", icon: getIcon()+"breeze4h_off.png", backgroundColor: "#ffffff", nextState: "turningBreezeOn"
         	state "turningOn", label:"ADJUSTING", action: "on", icon: getIcon()+"Fan.png", backgroundColor: "#2179b8", nextState: "turningOn"
             state "turningOff", label:"TURNING OFF", action:"off", icon: getIcon()+"Fan.png", backgroundColor:"#2179b8", nextState: "turningOff"
             state "turningBreezeOn", label:"ADJUSTING", action: "on", icon: getIcon()+"breeze4h_blk.png", backgroundColor: "#2179b8", nextState: "turningOn"

--- a/devicetypes/dcoffing/kof-zigbee-fan-controller-light-child-device.src/kof-zigbee-fan-controller-light-child-device.groovy
+++ b/devicetypes/dcoffing/kof-zigbee-fan-controller-light-child-device.src/kof-zigbee-fan-controller-light-child-device.groovy
@@ -13,9 +13,9 @@
  *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
  *  for the specific language governing permissions and limitations under the License.
  */
- def version() {return "ver 0.2.1.20170510x"}
+ def version() {return "ver 0.2.1.20170515"}
 /*
- 05/10  decoration: "flat" added to tile for consistancy across all childs; bug? it won't go flat look
+ 05/10  decoration: "flat" added to tile for consistancy across all childs
  05/05 edit Zigbee to proper ZigBee trademark
  05/04 clean up display in iOS child version, smaller text and center version
  05/03 tweak to icons for ON to match the lighter grey LED look
@@ -40,22 +40,32 @@ metadata {
    }
 
 	tiles(scale: 2) { 		
-        multiAttributeTile(name:"switch", type: "lighting", decoration: "flat", width: 6, height: 4, canChangeIcon: true) {
-    		tileAttribute ("switch", key: "PRIMARY_CONTROL") {
-        		attributeState "off", label:"off", action: "on", icon: getIcon()+"light_grey.png", backgroundColor: "#ffffff", nextState: "turningOn"
-				attributeState "on", label: "on", action: "off", icon: getIcon()+"lightH.png", backgroundColor: "#00A0DC", nextState: "turningOff"
-                attributeState "turningOn", label:"TURNING ON", action: "on", icon: getIcon()+"lightI.png", backgroundColor: "#2179b8", nextState: "turningOn"
-            	attributeState "turningOff", label:"TURNING OFF", action:"off", icon: getIcon()+"lightI.png", backgroundColor:"#2179b8", nextState: "turningOff"
-        	}    	
-    		tileAttribute ("device.level", key: "SLIDER_CONTROL") {
-        		attributeState "level", action: "setLevel"
-    		}  
-		}	
+        //multiAttributeTile(name:"switch", type: "lighting", width: 6, height: 4, canChangeIcon: true) {
+    	//	tileAttribute ("switch", key: "PRIMARY_CONTROL") {
+        //		attributeState "off", label:"off", action: "on", icon: getIcon()+"light_grey.png", backgroundColor: "#ffffff", nextState: "turningOn"
+		//		attributeState "on", label: "on", action: "off", icon: getIcon()+"lightH.png", backgroundColor: "#00A0DC", nextState: "turningOff"
+        //      attributeState "turningOn", label:"TURNING ON", action: "on", icon: getIcon()+"lightI.png", backgroundColor: "#2179b8", nextState: "turningOn"
+        //	attributeState "turningOff", label:"TURNING OFF", action:"off", icon: getIcon()+"lightI.png", backgroundColor:"#2179b8", nextState: "turningOff"
+        //	}    	
+    	//	tileAttribute ("device.level", key: "SLIDER_CONTROL") {
+        //		attributeState "level", action: "setLevel"
+    	//	}  
+		//}
+        
+         standardTile("switch", "switch", decoration: "flat", width: 6, height: 3, canChangeIcon: true) {    		
+        		state "off", label:"OFF", action: "on", icon: getIcon()+"light_grey.png", backgroundColor: "#ffffff", nextState: "turningOn"
+				state "on", label: "ON", action: "off", icon: getIcon()+"lightH.png", backgroundColor: "#00A0DC", nextState: "turningOff"
+                state "turningOn", label:"TURNING ON", action: "on", icon: getIcon()+"lightI.png", backgroundColor: "#2179b8", nextState: "turningOn"
+            	state "turningOff", label:"TURNING OFF", action:"off", icon: getIcon()+"lightI.png", backgroundColor:"#2179b8", nextState: "turningOff"
+        }    	
+    	controlTile ("level", "level", "slider", width: 6, height: 1) {
+        		state "level", action: "setLevel"
+    	}        
  		valueTile("version", "version", width: 6, height: 2) {
           	state "version", label:"\n Light Child \n" + version()+"\n"
 		}                
     	main(["switch"])        
-		details(["switch", "version"])    
+		details(["switch", "level", "version"])    
     }	
 }
 


### PR DESCRIPTION
Added version checks for child devices (new tiles turn green for current and red for outdated)

 NOTE: these versions will need to be manually changed in the parent

- removed Health Check capability until there is proper documentation on it's functionality
- removed childDeviceTile(s) code and replaced with separate childDeviceTile option for each so they can be easily rearranged.
- removed "power" check from parse() as recommended by @ranga
- fixed typo in createLightChild() that occurred when renaming from "LAMP" to "LIGHT"
     needs to be "-Light" instead of " Light" (dash was missing at line 270)
     @dalec will probably need to rebuild his devices